### PR TITLE
ローカルからS3に画像投稿を可能にする実装（開発環境）

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,4 @@ gem 'active_hash'
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'payjp' #payjpのgem導入
+gem "aws-sdk-s3", require: false #awsに画像をアップロードするためにS3のGem導入

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,6 +61,22 @@ GEM
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    aws-eventstream (1.2.0)
+    aws-partitions (1.715.0)
+    aws-sdk-core (3.170.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.5)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.62.0)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.119.1)
+      aws-sdk-core (~> 3, >= 3.165.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.4)
+    aws-sigv4 (1.5.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
     bindex (0.8.1)
     bootsnap (1.16.0)
@@ -112,6 +128,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     json (2.6.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -315,6 +332,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_hash
+  aws-sdk-s3
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon # awsのS3に保存されるよう変更
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,6 +6,14 @@ local:
   service: Disk
   root: <%= Rails.root.join("storage") %>
 
+amazon:
+ service: S3
+ region: ap-northeast-1
+ bucket: furima38426 # 画像をアップしたい「バケット名」を入力
+ # 環境変数を使用して、S3への認証情報を記述
+ access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+ secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
+
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:
 #   service: S3


### PR DESCRIPTION
# What
ローカルからAWS（S3）を使って、画像をアップロードできるように実装（開発環境）

# Why
Renderでは24時間で画像が削除されてしまうため、AWS（S3）を使って画像をアップロードできるように実装する

- [ ] _Gemfile_
S3を使用するために必要なGemfileを導入

- [ ] _config/environments/development.rb_
画像の保存先が「local」に設定されているとアプリケーション内に画像を保存することを意味するため、awsのS3に保存されるよう設定を変更

- [ ] _config/storage.yml_
storage.ymlにS3で使用するバケット名とリージョン名を記述
aws用の環境変数を設定した後、実際に環境変数を使用してS3への認証情報を記述