### PR TITLE
本番からS3に画像投稿を可能にする実装（本番環境）

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon # 本番環境もawsのS3に保存されるよう変更
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil


### PR DESCRIPTION
# What
本番環境からAWS（S3）を使って、画像をアップロードできるように実装（本番環境）

# Why
Renderでは24時間で画像が削除されてしまうため、AWS（S3）を使って画像をアップロードできるように実装するため、production.rbを修正

- [ ] _config/environments/production.rb_
画像の保存先が「local」に設定されているとアプリケーション内に画像を保存することを意味するため、awsのS3に保存されるよう設定を変更